### PR TITLE
Add cc-soul: local-first AI memory engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | **SimpleMem** | [aiming-lab/SimpleMem](https://github.com/aiming-lab/SimpleMem) | 开源 | 终身记忆层，支持跨对话的项目历史记忆。 |
 | **Supermemory** | [supermemory-ai/supermemory](https://github.com/supermemory-ai/supermemory) | 云原生 | 基于 Cloudflare 生态，构建分布式的个人 AI 记忆大脑。 |
 | **Khoj** | [khoj-ai/khoj](https://github.com/khoj-ai/khoj) | 多端 | 个人 AI 副驾驶，深度集成 Markdown 文档与笔记。 |
+| **cc-soul** | [npm: cc-soul](https://www.npmjs.com/package/cc-soul) | 本地优先/REST API | 三层记忆蒸馏 + 7 维激活场召回引擎，纯 SQLite 无需向量数据库，`npm install` 即用，支持任意 LLM 或零 LLM 离线运行。 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | **SimpleMem** | [aiming-lab/SimpleMem](https://github.com/aiming-lab/SimpleMem) | 开源 | 终身记忆层，支持跨对话的项目历史记忆。 |
 | **Supermemory** | [supermemory-ai/supermemory](https://github.com/supermemory-ai/supermemory) | 云原生 | 基于 Cloudflare 生态，构建分布式的个人 AI 记忆大脑。 |
 | **Khoj** | [khoj-ai/khoj](https://github.com/khoj-ai/khoj) | 多端 | 个人 AI 副驾驶，深度集成 Markdown 文档与笔记。 |
-| **cc-soul** | [npm: cc-soul](https://www.npmjs.com/package/cc-soul) | 本地优先/REST API | 三层记忆蒸馏 + 7 维激活场召回引擎，纯 SQLite 无需向量数据库，`npm install` 即用，支持任意 LLM 或零 LLM 离线运行。 |
+| **cc-soul** | [npm: @cc-soul/openclaw](https://www.npmjs.com/package/@cc-soul/openclaw) | 本地优先/REST API | 三层记忆蒸馏 + 7 维激活场召回引擎，纯 SQLite 无需向量数据库，`npm i @cc-soul/openclaw` 即用，支持任意 LLM 或零 LLM 离线运行。 |
 
 ---
 


### PR DESCRIPTION
## What is cc-soul?

cc-soul is a local-first AI memory engine designed for long-term personalization. It runs entirely on SQLite with no vector database dependency.

### Key Features
- **3-layer memory distillation**: Raw memories → Topic nodes (with hit/miss tournament) → Mental model (4-section user profile)
- **7-signal activation field (NAM)**: Recency, context, emotion, spreading activation, interference, temporal, sequential — no embedding model required
- **Zero-LLM mode**: Core recall works without any LLM, under 30ms local latency
- **REST API**: `POST /memories`, `POST /search`, `GET /health` — works with any LLM backend
- **Privacy-first**: All data stays local in SQLite, zero cloud upload, zero telemetry

### Install & Try
```bash
npm i @cc-soul/openclaw
npx cc-soul
curl http://localhost:18800/health
```

### Category
Added to **Section 2: Agent & Local Tools** — it fits alongside Basic Memory and SimpleMem as a local-first, privacy-friendly memory solution, but with significantly more sophisticated recall and distillation algorithms.

---
Submitted by the author.