### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | **NovelGenerator** | [KazKozDev/NovelGenerator](https://github.com/KazKozDev/NovelGenerator) | 多代理 | 跟踪人物视角、情节线与情感弧，适合生成完整小说。 |
 | **AgentCortex**| [sage-hq/agentcortex-mcp](https://github.com/sage-hq/agentcortex-mcp) | MCP | 原生 MCP 记忆系统，支持 Cursor 和 Claude Desktop。 |
 | **Basic Memory** | [basicmachines-co/basic-memory](https://github.com/basicmachines-co/basic-memory) | MCP/SQLite | 基于 SQLite 和 Markdown，极其隐私友好，适合本地知识库。 |
+| **Tree Ring Memory** | [TerminallyLazy/Tree-Ring-Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) | Rust/SQLite | 本地优先的 AI Agent 记忆生命周期 CLI/TUI，支持显式召回、审计、遗忘、压缩整合与 JSON 导出。 |
 | **Nano-GraphRAG**| [gusye1234/nano-graphrag](https://github.com/gusye1234/nano-graphrag) | 本地优化 | 极轻量级 GraphRAG 实现，适合资源受限环境。 |
 | **SimpleMem** | [aiming-lab/SimpleMem](https://github.com/aiming-lab/SimpleMem) | 开源 | 终身记忆层，支持跨对话的项目历史记忆。 |
 | **Supermemory** | [supermemory-ai/supermemory](https://github.com/supermemory-ai/supermemory) | 云原生 | 基于 Cloudflare 生态，构建分布式的个人 AI 记忆大脑。 |


### PR DESCRIPTION
## Summary
- Adds Tree Ring Memory to the Agentic & Local Tools section.
- Describes it as a local-first Rust/SQLite memory lifecycle CLI/TUI for AI agents.

## Validation
- git diff --check
- Confirmed the project link returns HTTP 200.