### PR TITLE
Add Lians agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | **NovelGenerator** | [KazKozDev/NovelGenerator](https://github.com/KazKozDev/NovelGenerator) | 多代理 | 跟踪人物视角、情节线与情感弧，适合生成完整小说。 |
 | **AgentCortex** | [sage-hq/agentcortex-mcp](https://github.com/sage-hq/agentcortex-mcp) | MCP | 原生 MCP 记忆系统，支持 Cursor 和 Claude Desktop。 |
 | **Basic Memory** | [basicmachines-co/basic-memory](https://github.com/basicmachines-co/basic-memory) | MCP/SQLite | 基于 SQLite 与 Markdown，极其隐私友好，适合本地知识库。 |
+| **Lians** | [Lians-ai/Lians](https://github.com/Lians-ai/Lians) | MCP/SQLite | 开源、本地优先的 AI Agent 记忆层，支持跨会话持久召回；提供 MCP、SDK 与桌面安装程序，无需账号或 API 密钥。 |
 | **Nano-GraphRAG** | [gusye1234/nano-graphrag](https://github.com/gusye1234/nano-graphrag) | 本地优化 | 极轻量级 GraphRAG 实现，适合资源受限环境。 |
 | **SimpleMem** | [aiming-lab/SimpleMem](https://github.com/aiming-lab/SimpleMem) | 开源 | 终身记忆层，支持跨对话的项目历史记忆。 |
 | **Supermemory** | [supermemoryai/supermemory](https://github.com/supermemoryai/supermemory) | 云原生 | 基于 Cloudflare 生态，构建分布式的个人 AI 记忆大脑。 |


### PR DESCRIPTION
## Summary

- add Lians to the agent-memory project directory
- describe its open-source, local-first MCP and SQLite surface
- link directly to the public repository

## Verification

- `git diff --check`
- confirmed the repository, Apache-2.0 license, and released MCP package are public

Disclosure: this contribution was prepared with AI assistance and reviewed by the submitter.