### PR TITLE
添加 LWC Agent 项目记忆工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | **NovelGenerator** | [KazKozDev/NovelGenerator](https://github.com/KazKozDev/NovelGenerator) | 多代理 | 跟踪人物视角、情节线与情感弧，适合生成完整小说。 |
 | **AgentCortex** | [sage-hq/agentcortex-mcp](https://github.com/sage-hq/agentcortex-mcp) | MCP | 原生 MCP 记忆系统，支持 Cursor 和 Claude Desktop。 |
 | **Basic Memory** | [basicmachines-co/basic-memory](https://github.com/basicmachines-co/basic-memory) | MCP/SQLite | 基于 SQLite 与 Markdown，极其隐私友好，适合本地知识库。 |
+| **LWC** | [JanYork/llm-wiki-cli](https://github.com/JanYork/llm-wiki-cli) | CLI/MCP/SQLite | Agent 驱动的主动项目记忆工具，维护跨会话、可追溯来源的持久知识，并提供全文检索、可选图谱及多宿主集成。 |
 | **Nano-GraphRAG** | [gusye1234/nano-graphrag](https://github.com/gusye1234/nano-graphrag) | 本地优化 | 极轻量级 GraphRAG 实现，适合资源受限环境。 |
 | **SimpleMem** | [aiming-lab/SimpleMem](https://github.com/aiming-lab/SimpleMem) | 开源 | 终身记忆层，支持跨对话的项目历史记忆。 |
 | **Supermemory** | [supermemoryai/supermemory](https://github.com/supermemoryai/supermemory) | 云原生 | 基于 Cloudflare 生态，构建分布式的个人 AI 记忆大脑。 |


### PR DESCRIPTION
## 变更说明

- 在“Agent 与本地记忆工具”中加入 LWC
- 描述采用项目官方定位，并标明 CLI、MCP 和 SQLite 形态
- 使用项目官方 GitHub 链接

LWC 是面向 AI Agent 的主动项目记忆 CLI，用于维护跨会话、可追溯来源的持久知识。

## 验证

- [x] GitHub 链接返回 HTTP 200
- [x] 仓库中不存在重复 LWC 条目
- [x] `git diff --check`
